### PR TITLE
Reintegration into drf generics

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -146,7 +146,7 @@ class OwnedObject(AbstractOwnedObject):
     Abstract object describing relation to a `Customer`.
     '''
     
-    owner = models.ForeignKey(customer_models.Customer, on_delete=models.CASCADE) 
+    owner = models.ForeignKey(customer_models.Customer, on_delete=models.CASCADE) # type: ignore
     public = models.BooleanField(default=False)
 
     class Meta:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -16,10 +16,10 @@
 from abc import abstractmethod, abstractstaticmethod
 from django.db import models
 from polymorphic.models import PolymorphicModel
-from django.db.models import constraints
+from django.db.models import constraints, manager, query
 from rest_framework import serializers
 from vycinity.models import customer_models, change_models
-from typing import Any, List
+from typing import Any, List, Union
 import uuid
 
 OWNED_OBJECT_STATE_PREPARED = 'prepared'
@@ -110,6 +110,27 @@ class AbstractOwnedObject(PolymorphicModel):
         '''
         return query.filter(models.Q(state=OWNED_OBJECT_STATE_LIVE) | models.Q(change__changeset=changeset))
 
+    @classmethod
+    def filter_by_changeset_and_visibility(cls, query: Union[manager.Manager, query.QuerySet], changeset: change_models.ChangeSet, visible_customers: list[customer_models.Customer]) -> Union[manager.Manager, query.QuerySet]:
+        '''
+        Returns a filtered queryset or manager (depends on what the implementing class provides)
+        for elements in same changeset and modified or live elements for the current user.
+
+        params:
+            query: A query to filter.
+            changeset: A Changeset for finding additional instances that are not live.
+            visible_customers: A list of customers the retriever is able to see.
+        
+        returns: The filtered queryset-like object.
+        '''
+        referenced_modified_changes = changeset.changes.filter(entity=cls.__name__, pre__isnull=False).only('pre')
+        pk_referenced_modified_objects_list = map(lambda change: change.pre.pk, referenced_modified_changes)
+        return cls.filter_query_by_customers_or_public(
+            query.filter(
+                (models.Q(state=OWNED_OBJECT_STATE_LIVE) & (~models.Q(pk__in=pk_referenced_modified_objects_list))) | 
+                models.Q(state=OWNED_OBJECT_STATE_PREPARED, change__changeset=changeset, change__action__in=[change_models.ACTION_CREATED, change_models.ACTION_MODIFIED])),
+            visible_customers)
+
     @abstractstaticmethod
     def get_serializer() -> serializers.Serializer:
         '''
@@ -125,7 +146,7 @@ class OwnedObject(AbstractOwnedObject):
     Abstract object describing relation to a `Customer`.
     '''
     
-    owner = models.ForeignKey(customer_models.Customer, on_delete=models.CASCADE)
+    owner = models.ForeignKey(customer_models.Customer, on_delete=models.CASCADE) 
     public = models.BooleanField(default=False)
 
     class Meta:

--- a/serializers/firewall_serializers.py
+++ b/serializers/firewall_serializers.py
@@ -13,9 +13,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with VyCinity. If not, see <https://www.gnu.org/licenses/>.
 
-from rest_framework import serializers
+from rest_framework import serializers, relations
+from rest_framework.request import Request
 from uuid import UUID
-from vycinity.models import customer_models, firewall_models, network_models
+from vycinity.models import OWNED_OBJECT_STATE_LIVE, AbstractOwnedObject, OwnedObject, customer_models, firewall_models, network_models, change_models
+
+class ManyWithoutNoneRelatedField(serializers.ManyRelatedField):
+    def to_representation(self, iterable):
+        return filter(lambda i: i is not None, [
+            self.child_relation.to_representation(value) # type: ignore
+            for value in iterable
+        ])
+
 
 class OwnedObjectRelatedField(serializers.RelatedField):
     '''
@@ -23,15 +32,62 @@ class OwnedObjectRelatedField(serializers.RelatedField):
     what we want, but it does not serialize UUIDs correctly.
     '''
 
+    def __init__(self, **kwargs):
+        self.model: OwnedObject = kwargs.pop('model')
+        if self.model is None:
+            raise AssertionError('OwnedObjectRelatedField requires an AbstractOwnedObject as model, but got None')
+        super().__init__(**kwargs)
+
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        list_kwargs = {'child_relation': cls(*args, **kwargs)}
+        for key in kwargs:
+            if key in relations.MANY_RELATION_KWARGS:
+                list_kwargs[key] = kwargs[key]
+        return ManyWithoutNoneRelatedField(**list_kwargs)
+
+    def get_queryset(self):
+        return self.model.objects.all()
+
     def to_representation(self, value):
-        return str(value.uuid)
+        if self.parent is None or not hasattr(self.parent, 'context') or self.parent.context is None:
+            raise AssertionError('Parent Field or serializer is not set properly but required for it\'s context.')
+        request = self.parent.context.get('request', None)
+        if not isinstance(request, Request):
+            raise AssertionError('Request is not set in context.')
+        if not isinstance(request.user, customer_models.User):
+            raise AssertionError('Related field requires an internal user for verifiying the visibility.')
+
+        if value.public or value.owner in request.user.customer.get_visible_customers():
+            return str(value.uuid)
+        else:
+            return None
 
     def to_internal_value(self, data):
+        if not isinstance(self.parent, serializers.BaseSerializer):
+            raise AssertionError('Parent serializer is not set but required for it\'s context.')
+        request = self.parent.context.get('request', None)
+        if not isinstance(request, Request):
+            raise AssertionError('Request is not set in context.')
+        if not isinstance(request.user, customer_models.User):
+            raise AssertionError('Related field requires an internal user for verifiying the visibility.')
         try:
+
             uuid = UUID(data)
-            result = self.get_queryset().filter(uuid=uuid).order_by('-pk').first()
+
+            result = None
+            visible_customers = request.user.customer.get_visible_customers()
+            if 'changeset' in request.query_params:
+                changeset_uuid = UUID(request.query_params['changeset'])
+                try:
+                    changeset = change_models.ChangeSet.objects.get(pk=changeset_uuid)
+                    result = self.model.filter_by_changeset_and_visibility(self.get_queryset().filter(uuid=uuid), changeset=changeset, visible_customers=visible_customers).order_by('-pk').first()
+                except change_models.ChangeSet.DoesNotExist:
+                    pass
+            else:
+                result = self.model.filter_query_by_customers_or_public(self.get_queryset().filter(uuid=uuid, state=OWNED_OBJECT_STATE_LIVE), visible_customers).order_by('-pk').first()
             if result is None:
-                serializers.ValidationError(['Referenced object not found.'])
+                raise serializers.ValidationError(['Referenced object not found.'])
             return result
         except ValueError as e:
             raise serializers.ValidationError(['Reference UUID is not valid.'])
@@ -42,7 +98,7 @@ class FirewallSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'owner', 'stateful', 'name', 'related_network', 'default_action_into', 'default_action_from', 'public']
         read_only_fields = ['uuid']
     owner = serializers.PrimaryKeyRelatedField(queryset=customer_models.Customer.objects.all(), pk_field=serializers.UUIDField(format='hex_verbose'), required=True)
-    related_network = OwnedObjectRelatedField(queryset=network_models.Network.objects.all(), required=False)
+    related_network = OwnedObjectRelatedField(model=network_models.Network, required=False)
 
 class RuleSetSerializer(serializers.ModelSerializer):
     class Meta:
@@ -50,14 +106,14 @@ class RuleSetSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'owner', 'priority', 'firewalls', 'comment', 'public']
         read_only_fields = ['uuid']
     owner = serializers.PrimaryKeyRelatedField(queryset=customer_models.Customer.objects.all(), pk_field=serializers.UUIDField(format='hex_verbose'), required=True)
-    firewalls = OwnedObjectRelatedField(many=True, queryset=firewall_models.Firewall.objects.all(), required=False)
+    firewalls = OwnedObjectRelatedField(many=True, model=firewall_models.Firewall, required=False)
 
 class RuleSerializer(serializers.ModelSerializer):
     class Meta:
         model = firewall_models.Rule
         fields = ['uuid', 'related_ruleset', 'priority', 'comment', 'disable']
         read_only_fields = ['uuid']
-    related_ruleset = OwnedObjectRelatedField(queryset=firewall_models.RuleSet.objects.all(), required=True)
+    related_ruleset = OwnedObjectRelatedField(model=firewall_models.RuleSet, required=True)
 
 class AddressObjectSerializer(serializers.ModelSerializer):
     class Meta:
@@ -78,17 +134,17 @@ class BasicRuleSerializer(serializers.ModelSerializer):
         model = firewall_models.BasicRule
         fields = ['uuid', 'related_ruleset', 'priority', 'comment', 'disable', 'source_address', 'destination_address', 'destination_service', 'action', 'log']
         read_only_fields = ['uuid']
-    related_ruleset = OwnedObjectRelatedField(queryset=firewall_models.RuleSet.objects.all(), required=True)
-    source_address = OwnedObjectRelatedField(queryset=firewall_models.AddressObject.objects.all(), required=False)
-    destination_address = OwnedObjectRelatedField(queryset=firewall_models.AddressObject.objects.all(), required=True)
-    destination_service = OwnedObjectRelatedField(queryset=firewall_models.ServiceObject.objects.all(), required=False)
+    related_ruleset = OwnedObjectRelatedField(model=firewall_models.RuleSet, required=True)
+    source_address = OwnedObjectRelatedField(model=firewall_models.AddressObject, required=False)
+    destination_address = OwnedObjectRelatedField(model=firewall_models.AddressObject, required=True)
+    destination_service = OwnedObjectRelatedField(model=firewall_models.ServiceObject, required=False)
 
 class CustomRuleSerializer(serializers.ModelSerializer):
     class Meta:
         model = firewall_models.CustomRule
         fields = ['id', 'related_ruleset', 'priority', 'comment', 'disable', 'ip_version', 'rule']
         read_only_fields = ['id']
-    related_ruleset = OwnedObjectRelatedField(queryset=firewall_models.RuleSet.objects.all(), required=True)
+    related_ruleset = OwnedObjectRelatedField(model=firewall_models.RuleSet, required=True)
 
 class NetworkAddressObjectSerializer(serializers.ModelSerializer):
     class Meta:
@@ -96,7 +152,7 @@ class NetworkAddressObjectSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'name', 'owner', 'public', 'related_network']
         read_only_fields = ['uuid']
     owner = serializers.PrimaryKeyRelatedField(queryset=customer_models.Customer.objects.all(), pk_field=serializers.UUIDField(format='hex_verbose'), required=True)
-    related_network = OwnedObjectRelatedField(queryset=network_models.Network.objects.all(), required=True)
+    related_network = OwnedObjectRelatedField(model=network_models.Network, required=True)
 
 class CIDRAddressObjectSerializer(serializers.ModelSerializer):
     class Meta:
@@ -118,7 +174,7 @@ class ListAddressObjectSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'name', 'owner', 'public', 'elements']
         read_only_fields = ['uuid']
     owner = serializers.PrimaryKeyRelatedField(queryset=customer_models.Customer.objects.all(), pk_field=serializers.UUIDField(format='hex_verbose'), required=True)
-    elements = OwnedObjectRelatedField(many=True, queryset=firewall_models.AddressObject.objects.all(), required=False)
+    elements = OwnedObjectRelatedField(many=True, model=firewall_models.AddressObject, required=False)
 
 class SimpleServiceObjectSerializer(serializers.ModelSerializer):
     class Meta:
@@ -133,7 +189,7 @@ class ListServiceObjectSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'name', 'owner', 'public', 'elements']
         read_only_fields = ['uuid']
     owner = serializers.PrimaryKeyRelatedField(queryset=customer_models.Customer.objects.all(), pk_field=serializers.UUIDField(format='hex_verbose'), required=True)
-    elements = OwnedObjectRelatedField(many=True, queryset=firewall_models.ServiceObject.objects.all(), required=False)
+    elements = OwnedObjectRelatedField(many=True, model=firewall_models.ServiceObject, required=False)
 
 class RangeServiceObjectSerializer(serializers.ModelSerializer):
     class Meta:

--- a/serializers/generics.py
+++ b/serializers/generics.py
@@ -1,0 +1,72 @@
+# This file is part of VyCinity.
+# 
+# VyCinity is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+# 
+# VyCinity is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with VyCinity. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Type
+from django.forms import ValidationError
+from django.http import HttpRequest
+from rest_framework import serializers
+from rest_framework.fields import Field
+from vycinity.models import OWNED_OBJECT_STATE_LIVE, OWNED_OBJECT_STATE_PREPARED, AbstractOwnedObject, OwnedObject
+from vycinity.models.change_models import ChangeSet, ACTION_DELETED, ACTION_MODIFIED
+from vycinity.models.customer_models import Customer, User
+from vycinity.views import CHANGESET_APPLIED_ERROR
+import uuid
+
+class BaseOwnedObjectSerializer(serializers.ModelSerializer):
+    def update(self, instance, validated_data):
+        if not isinstance(instance, OwnedObject):
+            raise AssertionError('Instance is no OwnedObject. This is a programming issue.')
+        request: HttpRequest = self._context['request']
+        if not request:
+            raise AssertionError('request is not set as context for this serializer. This makes operation impossible.')
+        if not isinstance(request.user, User):
+            raise AssertionError('request\'s user is not based on internal user definition. This makes changes impossible.')
+        if not hasattr(self, 'Meta'):
+            raise AssertionError('Meta is missing in this serializer')
+        if not hasattr(self.Meta, 'model'): # type: ignore
+            raise AssertionError('Meta\'s model is missing in this serializer')
+        
+        changeset = None
+        change = None
+        if 'changeset' in request.GET:
+            changeset = ChangeSet.objects.get(pk=uuid.UUID(request.GET['changeset']), owner__in=request.user.customer.get_visible_customers())
+            if changeset.applied is not None:
+                raise ValidationError(message = CHANGESET_APPLIED_ERROR)
+            model: type[OwnedObject] = self.Meta.model # type: ignore
+            thisname = model.__name__
+            for actual_change in changeset.changes.all():
+                if actual_change.entity == thisname and actual_change.post.uuid == instance.uuid:
+                    instance = model.objects.get(pk=actual_change.post.pk)
+                    change = actual_change
+                    if change.action == ACTION_DELETED:
+                        change.action = ACTION_MODIFIED
+                    break
+        else:
+            changeset = ChangeSet(owner=request.user.customer, user=request.user, owner_name=request.user.customer.name, user_name=request.user.name)
+        
+        modified_instance = None
+        if instance.state == OWNED_OBJECT_STATE_LIVE:
+            modified_instance = self._model.objects.get(pk=instance.pk)
+            modified_instance.pk = None
+            modified_instance.id = None
+            modified_instance._state.adding = True
+            
+        elif instance.state == OWNED_OBJECT_STATE_PREPARED:
+            modified_instance = instance
+
+        raise NotImplementedError()
+
+    def create(self, validated_data):
+        raise NotImplementedError()

--- a/serializers/generics.py
+++ b/serializers/generics.py
@@ -30,24 +30,6 @@ class BaseOwnedObjectSerializer(serializers.ModelSerializer):
 
     changeset = serializers.SerializerMethodField()
 
-    # def to_internal_value(self, data):
-    #     '''
-    #     This overrides just checks the data a little bit, else uses ModelSerializers behavior.
-    #     '''
-    #     data = super().to_internal_value(data)
-
-    #     request: Request = self._context['request']
-    #     if not request or not isinstance(request, Request):
-    #         raise AssertionError('request is not set as context for this serializer (or has wrong type). This makes operation impossible.', request)
-    #     if 'changeset' in request.query_params:
-    #         try:
-    #             changeset = ChangeSet.objects.get(pk=uuid.UUID(request.query_params['changeset']), owner__in=request.user.customer.get_visible_customers())
-    #             if changeset.applied is not None:
-    #                 raise ValidationError(message = CHANGESET_APPLIED_ERROR)
-    #         except ChangeSet.DoesNotExist as e:
-    #             raise serializers.ValidationError(['Change set does not exist']) from e
-    #     return data
-
     def get_changeset(self, obj: OwnedObject):
         if obj.change is None:
             return None
@@ -117,30 +99,6 @@ class BaseOwnedObjectSerializer(serializers.ModelSerializer):
         change.post = modified_instance
         change.save()
 
-        # if not instance.owned_by(request.user.customer):
-        #         return Response(data={'id':['Access to object denied']}, status=status.HTTP_403_FORBIDDEN)
-        #     serializer = self.get_serializer()(instance, data=request.data)
-        #     if serializer.is_valid():
-        #         if self.validate_owner():
-        #             if not serializer.validated_data['owner'] in request.user.customer.get_visible_customers():
-        #                 return Response(data={'owner':['access to the owner is denied']}, status=status.HTTP_403_FORBIDDEN)
-        #         semantic_validation = self.put_validate(serializer.validated_data, request.user.customer, changeset)
-        #         if semantic_validation.is_ok():
-        #             prepared_object = serializer.save(state=OWNED_OBJECT_STATE_PREPARED)
-        #             changeset.save()
-        #             change.changeset = changeset
-        #             change.post = prepared_object
-        #             change.save()
-        #             serialized_data = self.get_serializer()(prepared_object).data
-        #             serialized_data['changeset'] = str(changeset.id)
-        #             return Response(serialized_data)
-        #         else:
-        #             rtncode = status.HTTP_400_BAD_REQUEST
-        #             if not semantic_validation.access_ok:
-        #                 rtncode = status.HTTP_403_FORBIDDEN
-        #             return Response(data=semantic_validation.errors, status=rtncode)
-        #     else:
-        #         return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         return modified_instance
 
     def create(self, validated_data):

--- a/serializers/generics.py
+++ b/serializers/generics.py
@@ -14,37 +14,65 @@
 # along with VyCinity. If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Type
-from django.forms import ValidationError
-from django.http import HttpRequest
 from rest_framework import serializers
-from rest_framework.fields import Field
+from rest_framework.relations import ManyRelatedField
+from rest_framework.request import Request
 from vycinity.models import OWNED_OBJECT_STATE_LIVE, OWNED_OBJECT_STATE_PREPARED, AbstractOwnedObject, OwnedObject
-from vycinity.models.change_models import ChangeSet, ACTION_DELETED, ACTION_MODIFIED
+from vycinity.models.change_models import Change, ChangeSet, ACTION_DELETED, ACTION_MODIFIED
 from vycinity.models.customer_models import Customer, User
 from vycinity.views import CHANGESET_APPLIED_ERROR
 import uuid
 
 class BaseOwnedObjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = ['uuid', 'changeset']
+        read_only_fields = ['uuid', 'changeset']
+
+    changeset = serializers.SerializerMethodField()
+
+    # def to_internal_value(self, data):
+    #     '''
+    #     This overrides just checks the data a little bit, else uses ModelSerializers behavior.
+    #     '''
+    #     data = super().to_internal_value(data)
+
+    #     request: Request = self._context['request']
+    #     if not request or not isinstance(request, Request):
+    #         raise AssertionError('request is not set as context for this serializer (or has wrong type). This makes operation impossible.', request)
+    #     if 'changeset' in request.query_params:
+    #         try:
+    #             changeset = ChangeSet.objects.get(pk=uuid.UUID(request.query_params['changeset']), owner__in=request.user.customer.get_visible_customers())
+    #             if changeset.applied is not None:
+    #                 raise ValidationError(message = CHANGESET_APPLIED_ERROR)
+    #         except ChangeSet.DoesNotExist as e:
+    #             raise serializers.ValidationError(['Change set does not exist']) from e
+    #     return data
+
+    def get_changeset(self, obj: OwnedObject):
+        if obj.change is None:
+            return None
+        return str(obj.change.get().changeset.id)
+
     def update(self, instance, validated_data):
         if not isinstance(instance, OwnedObject):
             raise AssertionError('Instance is no OwnedObject. This is a programming issue.')
-        request: HttpRequest = self._context['request']
-        if not request:
-            raise AssertionError('request is not set as context for this serializer. This makes operation impossible.')
+        request: Request = self._context['request']
+        if not request or not isinstance(request, Request):
+            raise AssertionError('request is not set as context for this serializer (or has wrong type). This makes operation impossible.', request)
         if not isinstance(request.user, User):
             raise AssertionError('request\'s user is not based on internal user definition. This makes changes impossible.')
         if not hasattr(self, 'Meta'):
             raise AssertionError('Meta is missing in this serializer')
         if not hasattr(self.Meta, 'model'): # type: ignore
             raise AssertionError('Meta\'s model is missing in this serializer')
-        
+        model: type[OwnedObject] = self.Meta.model # type: ignore
+
         changeset = None
         change = None
-        if 'changeset' in request.GET:
-            changeset = ChangeSet.objects.get(pk=uuid.UUID(request.GET['changeset']), owner__in=request.user.customer.get_visible_customers())
+        if 'changeset' in request.query_params:
+            changeset = ChangeSet.objects.get(pk=uuid.UUID(request.query_params['changeset']), owner__in=request.user.customer.get_visible_customers())
             if changeset.applied is not None:
-                raise ValidationError(message = CHANGESET_APPLIED_ERROR)
-            model: type[OwnedObject] = self.Meta.model # type: ignore
+                raise serializers.ValidationError('nope!')
             thisname = model.__name__
             for actual_change in changeset.changes.all():
                 if actual_change.entity == thisname and actual_change.post.uuid == instance.uuid:
@@ -55,18 +83,65 @@ class BaseOwnedObjectSerializer(serializers.ModelSerializer):
                     break
         else:
             changeset = ChangeSet(owner=request.user.customer, user=request.user, owner_name=request.user.customer.name, user_name=request.user.name)
+            change = Change(changeset=changeset, entity=model.__name__, action=ACTION_MODIFIED)
         
-        modified_instance = None
+        modified_instance: OwnedObject
         if instance.state == OWNED_OBJECT_STATE_LIVE:
-            modified_instance = self._model.objects.get(pk=instance.pk)
+            modified_instance: OwnedObject = model.objects.get(pk=instance.pk)
             modified_instance.pk = None
             modified_instance.id = None
             modified_instance._state.adding = True
-            
+            change.pre = instance # type: ignore
         elif instance.state == OWNED_OBJECT_STATE_PREPARED:
             modified_instance = instance
+        else:
+            raise AssertionError('Update called on object with state neither live or prepared', instance)
 
-        raise NotImplementedError()
+        modified_instance.state = OWNED_OBJECT_STATE_PREPARED
+        later_put_fields = {}
+        all_fields = self.fields
+        for key, validated_value in validated_data.items():
+            if key not in all_fields.keys():
+                raise AssertionError(f'Field {key} is not defined.')
+            if all_fields[key].read_only:
+                continue
+            if isinstance(self.fields[key], ManyRelatedField):
+                later_put_fields[key] = validated_value
+                continue
+            setattr(modified_instance, key, validated_value)
+        modified_instance.save()
+        for key, validated_value in later_put_fields.items():
+            manager = getattr(modified_instance, key)
+            manager.set(validated_value)
+        changeset.save()
+        change.post = modified_instance
+        change.save()
+
+        # if not instance.owned_by(request.user.customer):
+        #         return Response(data={'id':['Access to object denied']}, status=status.HTTP_403_FORBIDDEN)
+        #     serializer = self.get_serializer()(instance, data=request.data)
+        #     if serializer.is_valid():
+        #         if self.validate_owner():
+        #             if not serializer.validated_data['owner'] in request.user.customer.get_visible_customers():
+        #                 return Response(data={'owner':['access to the owner is denied']}, status=status.HTTP_403_FORBIDDEN)
+        #         semantic_validation = self.put_validate(serializer.validated_data, request.user.customer, changeset)
+        #         if semantic_validation.is_ok():
+        #             prepared_object = serializer.save(state=OWNED_OBJECT_STATE_PREPARED)
+        #             changeset.save()
+        #             change.changeset = changeset
+        #             change.post = prepared_object
+        #             change.save()
+        #             serialized_data = self.get_serializer()(prepared_object).data
+        #             serialized_data['changeset'] = str(changeset.id)
+        #             return Response(serialized_data)
+        #         else:
+        #             rtncode = status.HTTP_400_BAD_REQUEST
+        #             if not semantic_validation.access_ok:
+        #                 rtncode = status.HTTP_403_FORBIDDEN
+        #             return Response(data=semantic_validation.errors, status=rtncode)
+        #     else:
+        #         return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return modified_instance
 
     def create(self, validated_data):
         raise NotImplementedError()

--- a/serializers/generics.py
+++ b/serializers/generics.py
@@ -18,22 +18,50 @@ from rest_framework import serializers
 from rest_framework.relations import ManyRelatedField
 from rest_framework.request import Request
 from vycinity.models import OWNED_OBJECT_STATE_LIVE, OWNED_OBJECT_STATE_PREPARED, AbstractOwnedObject, OwnedObject
-from vycinity.models.change_models import Change, ChangeSet, ACTION_DELETED, ACTION_MODIFIED
+from vycinity.models.change_models import Change, ChangeSet, ACTION_CREATED, ACTION_DELETED, ACTION_MODIFIED
 from vycinity.models.customer_models import Customer, User
 from vycinity.views import CHANGESET_APPLIED_ERROR
 import uuid
 
 class BaseOwnedObjectSerializer(serializers.ModelSerializer):
     class Meta:
-        fields = ['uuid', 'changeset']
+        fields = ['uuid', 'owner', 'changeset']
         read_only_fields = ['uuid', 'changeset']
 
+    owner = serializers.PrimaryKeyRelatedField(queryset=Customer.objects.all(), pk_field=serializers.UUIDField(format='hex_verbose'), required=True)
     changeset = serializers.SerializerMethodField()
 
+    def validate_owner(self, value):
+        request: Request = self._context['request']
+        if not request or not isinstance(request, Request):
+            raise AssertionError('request is not set as context for this serializer (or has wrong type). This causes errors while validation.', request)
+        if value not in request.user.customer.get_visible_customers():
+            raise serializers.ValidationError(['Owner is not accessible by current user.'])
+        return value
+
     def get_changeset(self, obj: OwnedObject):
-        if obj.change is None:
+        request: Request = self._context['request']
+        if not request or not isinstance(request, Request):
+            raise AssertionError('request is not set as context for this serializer (or has wrong type). This causes errors while serialization.', request)
+        if request.method == 'GET' and 'changeset' not in request.query_params:
             return None
-        return str(obj.change.get().changeset.id)
+        if 'changeset' in request.query_params:
+            changeset_uuid = uuid.UUID(request.query_params['changeset'])
+            try:
+                change = obj.change.get()
+                if change.changeset.id == changeset_uuid:
+                    return changeset_uuid
+            except Change.DoesNotExist:
+                # This should not happen, but is not necessary an error.
+                return None
+        elif request.method in ['POST', 'PATCH', 'PUT']:
+            try:
+                change = obj.change.get()
+                return change.changeset.id
+            except Change.DoesNotExist:
+                # This should not happen, but is not necessary an error.
+                return None
+        return None
 
     def update(self, instance, validated_data):
         if not isinstance(instance, OwnedObject):
@@ -54,7 +82,7 @@ class BaseOwnedObjectSerializer(serializers.ModelSerializer):
         if 'changeset' in request.query_params:
             changeset = ChangeSet.objects.get(pk=uuid.UUID(request.query_params['changeset']), owner__in=request.user.customer.get_visible_customers())
             if changeset.applied is not None:
-                raise serializers.ValidationError('nope!')
+                raise serializers.ValidationError('Changeset is already applied.')
             thisname = model.__name__
             for actual_change in changeset.changes.all():
                 if actual_change.entity == thisname and actual_change.post.uuid == instance.uuid:
@@ -65,6 +93,7 @@ class BaseOwnedObjectSerializer(serializers.ModelSerializer):
                     break
         else:
             changeset = ChangeSet(owner=request.user.customer, user=request.user, owner_name=request.user.customer.name, user_name=request.user.name)
+        if change is None:
             change = Change(changeset=changeset, entity=model.__name__, action=ACTION_MODIFIED)
         
         modified_instance: OwnedObject
@@ -101,5 +130,47 @@ class BaseOwnedObjectSerializer(serializers.ModelSerializer):
 
         return modified_instance
 
+
     def create(self, validated_data):
-        raise NotImplementedError()
+        request: Request = self._context['request']
+        if not request or not isinstance(request, Request):
+            raise AssertionError('request is not set as context for this serializer (or has wrong type). This makes operation impossible.', request)
+        if not isinstance(request.user, User):
+            raise AssertionError('request\'s user is not based on internal user definition. This makes changes impossible.')
+        if not hasattr(self, 'Meta'):
+            raise AssertionError('Meta is missing in this serializer')
+        if not hasattr(self.Meta, 'model'): # type: ignore
+            raise AssertionError('Meta\'s model is missing in this serializer')
+        model: type[OwnedObject] = self.Meta.model # type: ignore
+
+        changeset = None
+        if 'changeset' in request.query_params:
+            changeset = ChangeSet.objects.get(pk=uuid.UUID(request.query_params['changeset']), owner__in=request.user.customer.get_visible_customers())
+            if changeset.applied is not None:
+                raise serializers.ValidationError('Changeset is already applied')
+        else:
+            changeset = ChangeSet(owner=request.user.customer, user=request.user, owner_name=request.user.customer.name, user_name=request.user.name)
+        change = Change(changeset=changeset, entity=model.__name__, action=ACTION_CREATED)
+
+        instance = model()
+        instance.state = OWNED_OBJECT_STATE_PREPARED
+        later_put_fields = {}
+        all_fields = self.fields
+        for key, validated_value in validated_data.items():
+            if key not in all_fields.keys():
+                raise AssertionError(f'Field {key} is not defined.')
+            if all_fields[key].read_only:
+                continue
+            if isinstance(self.fields[key], ManyRelatedField):
+                later_put_fields[key] = validated_value
+                continue
+            setattr(instance, key, validated_value)
+        instance.save()
+        for key, validated_value in later_put_fields.items():
+            manager = getattr(instance, key)
+            manager.set(validated_value)
+        changeset.save()
+        change.post = instance
+        change.save()
+
+        return instance

--- a/serializers/network_serializers.py
+++ b/serializers/network_serializers.py
@@ -28,11 +28,11 @@ class ManagedInterfaceSerializer(serializers.ModelSerializer):
         model = ManagedInterface
         fields = ['id', 'router', 'ipv4_address', 'ipv6_address', 'network']
         read_only_fields = ['id']
-    network = OwnedObjectRelatedField(queryset=Network.objects.all(), required=True)
+    network = OwnedObjectRelatedField(model=Network.objects, required=True)
 
 class ManagedVRRPInterfaceSerializer(serializers.ModelSerializer):
     class Meta:
         model = ManagedVRRPInterface
         fields = ['id', 'router', 'ipv4_address', 'ipv6_address', 'network', 'ipv4_service_address', 'ipv6_service_address', 'priority', 'vrid']
         read_only_fields = ['id']
-    network = OwnedObjectRelatedField(queryset=Network.objects.all(), required=True)
+    network = OwnedObjectRelatedField(model=Network.objects, required=True)

--- a/tests/test_int_generic_view.py
+++ b/tests/test_int_generic_view.py
@@ -280,7 +280,7 @@ class GenericAPITest(TestCase):
         changeset = change_models.ChangeSet.objects.create(owner=self.main_customer, user=self.main_user, owner_name=self.main_customer.name, user_name=self.main_user.name)
         ruleset_in_changeset: firewall_models.RuleSet = firewall_models.RuleSet.objects.create(comment='my ruleset', owner=self.main_customer, public=False, priority=14, state=OWNED_OBJECT_STATE_PREPARED)
         ruleset_in_changeset.firewalls.set([self.firewall_main_user])
-        change_models.Change.objects.create(changeset=changeset, entity=firewall_models.RuleSet.__name__, post=ruleset_in_changeset)
+        change_models.Change.objects.create(changeset=changeset, entity=firewall_models.RuleSet.__name__, post=ruleset_in_changeset, action=change_models.ACTION_CREATED)
         
         response = c.post('/api/v1/rules/basic?changeset={}'.format(changeset.id), {'related_ruleset': str(ruleset_in_changeset.uuid), 'priority': 10, 'disable': False, 'destination_address': str(any_address_object.uuid), 'log': False, 'action': 'accept'}, HTTP_ACCEPT='application/json', HTTP_AUTHORIZATION=self.authorization)
         self.assertEqual(201, response.status_code)

--- a/tests/test_int_generic_view.py
+++ b/tests/test_int_generic_view.py
@@ -361,7 +361,7 @@ class GenericAPITest(TestCase):
         self.assertEqual(content['public'], change_in_modified_set.post.ruleset.public)
         self.assertEqual(content['priority'], change_in_modified_set.post.ruleset.priority)
 
-        # correct case for deleted ruleset in changeset, resurrected
+        # wrong case for deleted ruleset in changeset, resurrection is not possible
         changeset_w_deleted_ruleset = change_models.ChangeSet.objects.create(owner=self.main_customer, owner_name=self.main_customer.name, user=self.main_user, user_name=self.main_user.name)
         deleted_ruleset = firewall_models.RuleSet.objects.get(pk=self.private_ruleset_main_user.pk)
         deleted_ruleset.id = None
@@ -371,38 +371,22 @@ class GenericAPITest(TestCase):
         deleted_ruleset.save()
         change_models.Change.objects.create(changeset=changeset_w_deleted_ruleset, entity=firewall_models.RuleSet.__name__, pre=self.private_ruleset_main_user, post=deleted_ruleset, action=change_models.ACTION_DELETED)
         response = c.put('/api/v1/rulesets/%s?changeset=%s' % (self.private_ruleset_main_user.uuid, changeset_w_deleted_ruleset.id), json.dumps({'comment': 'main private ruleset resurrected', 'owner': str(self.private_ruleset_main_user.owner.id), 'priority': 27, 'public': False}), content_type='application/json', HTTP_AUTHORIZATION=self.authorization)
-        self.assertEqual(200, response.status_code)
-        content = response.json()
-        self.assertTrue(isinstance(content, dict))
-        self.assertEqual('main private ruleset resurrected', content['comment'])
-        self.assertEqual(str(self.private_ruleset_main_user.owner.id), content['owner'])
-        self.assertEqual(27, content['priority'])
-        self.assertFalse(content['public'])
-        self.assertListEqual([], content['firewalls'])
-        self.assertEqual(str(changeset_w_deleted_ruleset.id), content['changeset'])
-        modified_changeset = change_models.ChangeSet.objects.get(id=changeset_w_deleted_ruleset.id)
-        self.assertEqual(1, modified_changeset.changes.count())
-        change_in_modified_set = modified_changeset.changes.first()
-        self.assertEqual(self.private_ruleset_main_user.pk, change_in_modified_set.pre.pk)
-        self.assertEqual(deleted_ruleset.pk, change_in_modified_set.post.pk)
-        self.assertEqual(content['comment'], change_in_modified_set.post.ruleset.comment)
-        self.assertEqual(content['owner'], str(change_in_modified_set.post.ruleset.owner.id))
-        self.assertEqual(0, change_in_modified_set.post.ruleset.firewalls.count())
-        self.assertEqual(content['public'], change_in_modified_set.post.ruleset.public)
-        self.assertEqual(content['priority'], change_in_modified_set.post.ruleset.priority)
-        self.assertEqual(change_models.ACTION_MODIFIED, change_in_modified_set.action)
+        self.assertEqual(404, response.status_code)
 
         # wrong case: sub customer must not use firewall which is not accessible
         response = c.put('/api/v1/rulesets/%s' % sub_customer_ruleset.uuid, json.dumps({'comment': 'sub customer ruleset 2', 'owner': str(sub_customer.id), 'priority': 12, 'public': False, 'firewalls':[str(self.firewall_main_user.uuid)]}), content_type='application/json', HTTP_ACCEPT='application/json', HTTP_AUTHORIZATION=self.authorization)
-        self.assertEqual(403, response.status_code)
+        self.assertLessEqual(400, response.status_code)
+        self.assertGreater(500, response.status_code)
         
         # wrong case: other customers ruleset must not be changable
         response = c.put('/api/v1/rulesets/%s' % self.private_ruleset_other_user.uuid, json.dumps({'comment': 'my ruleset 2', 'owner': str(self.other_customer.id), 'priority': 10, 'public': False, 'firewalls':[str(self.firewall_other_user.uuid)]}), content_type='application/json', HTTP_ACCEPT='application/json', HTTP_AUTHORIZATION=self.authorization)
-        self.assertEqual(403, response.status_code)
+        self.assertLess(400, response.status_code)
+        self.assertGreater(500, response.status_code)
         
         # wrong case: ruleset must not be transferable to customer which is not accessible
         response = c.put('/api/v1/rulesets/%s' % self.private_ruleset_main_user.uuid, json.dumps({'comment': 'my ruleset 2', 'owner': str(self.other_customer.id), 'priority': 10, 'public': False, 'firewalls':[str(self.firewall_other_user.uuid)]}), content_type='application/json', HTTP_ACCEPT='application/json', HTTP_AUTHORIZATION=self.authorization)
-        self.assertEqual(403, response.status_code)
+        self.assertLessEqual(400, response.status_code)
+        self.assertGreater(500, response.status_code)
         
         # wrong case: ruleset must be consistent
         response = c.put('/api/v1/rulesets/%s' % self.private_ruleset_main_user.uuid, json.dumps({'comment': 'sub customer ruleset 2', 'owner': str(self.main_customer.id), 'priority': 12, 'public': False, 'firewalls': [str(uuid.uuid4())]}), content_type='application/json', HTTP_ACCEPT='application/json', HTTP_AUTHORIZATION=self.authorization)

--- a/tests/test_int_generic_view.py
+++ b/tests/test_int_generic_view.py
@@ -227,7 +227,7 @@ class GenericAPITest(TestCase):
 
         # case without access
         response2 = c.get('/api/v1/rulesets/%s' % self.private_ruleset_other_user.uuid, HTTP_ACCEPT='application/json', HTTP_AUTHORIZATION=self.authorization)
-        self.assertEqual(403, response2.status_code)
+        self.assertLess(400, response2.status_code)
 
     def test_post_ruleset(self):
         c = Client()

--- a/tests/test_int_generic_view.py
+++ b/tests/test_int_generic_view.py
@@ -429,15 +429,7 @@ class GenericAPITest(TestCase):
         unlinked_ruleset.firewalls.set([])
         change_unlinked_ruleset = change_models.Change.objects.create(changeset=changeset_w_unlinked_ruleset, entity=firewall_models.RuleSet.__name__, pre=self.private_ruleset_main_user, post=unlinked_ruleset, action=change_models.ACTION_DELETED)
         response = c.delete('/api/v1/rulesets/%s?changeset=%s' % (self.private_ruleset_main_user.uuid, changeset_w_unlinked_ruleset.id), HTTP_AUTHORIZATION=self.authorization)
-        self.assertEqual(200, response.status_code)
-        content = response.json()
-        self.assertEqual(changeset_w_unlinked_ruleset.id, uuid.UUID(content['changeset']))
-        changeset_containing_change = change_models.ChangeSet.objects.get(id=content['changeset'])
-        self.assertEqual(1, changeset_containing_change.changes.count())
-        self.assertEqual(firewall_models.RuleSet.__name__, changeset_containing_change.changes.first().entity)
-        self.assertEqual(unlinked_ruleset.pk, changeset_containing_change.changes.first().post.pk)
-        self.assertEqual(OWNED_OBJECT_STATE_DELETED, changeset_containing_change.changes.first().post.state)
-        self.assertEqual(self.private_ruleset_main_user.pk, changeset_containing_change.changes.first().pre.pk)
+        self.assertEqual(404, response.status_code)
 
         # wrong case: rulesets of other customer must not be deleted
         other_customers_public_ruleset_id = self.public_ruleset_other_user.uuid

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -17,7 +17,7 @@ from abc import ABC, abstractmethod
 from django.http import Http404, HttpResponseForbidden
 from django.db.models import Q
 from rest_framework import exceptions, status
-from rest_framework.generics import RetrieveUpdateDestroyAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -79,7 +79,7 @@ class GenericSchema(AutoSchema):
     def get_serializer(self, path, method):
         return self.serializer()
 
-class GenericOwnedObjectList(APIView, ABC):
+class GenericOwnedObjectList(ListCreateAPIView, ABC):
     permission_classes = [IsOwnerOfObjectOrPublicObject]
 
     @abstractmethod
@@ -87,7 +87,7 @@ class GenericOwnedObjectList(APIView, ABC):
         raise NotImplementedError('Model is not set.')
 
     @abstractmethod
-    def get_serializer(self) -> Type[Serializer]:
+    def get_serializer_class(self) -> Type[Serializer]:
         raise NotImplementedError('Serializer is not set.')
 
     @abstractmethod
@@ -101,71 +101,26 @@ class GenericOwnedObjectList(APIView, ABC):
     def validate_owner(self):
         return True
 
-    def get(self, request, format=None):
-        model = self.get_model()
-        relevant_changes: List[change_models.Change] = []
-        if 'changeset' in request.GET:
+    def get_queryset(self):
+        '''
+        Overrides ListCreateAPIView.get_queryset(). Returns a queryset including the current changeset.
+        '''
+        if not isinstance(self.request.user, customer_models.User):
+            raise AssertionError('Non usable user tries to retrieve an owned object.')
+
+        request: Request = self.request # type: ignore
+        visible_customers = request.user.customer.get_visible_customers()
+        if 'changeset' in request.query_params:
             try:
-                changeset = change_models.ChangeSet.objects.get(id=request.GET['changeset'])
-                if not changeset.owner in request.user.customer.get_visible_customers():
-                    return HttpResponseForbidden()
-                for change in changeset.changes.all():
-                    if change.entity == self.get_model().__name__:
-                        relevant_changes.append(change)
-                        break
-            except change_models.ChangeSet.DoesNotExist as dne_exc:
-                raise Http404() from dne_exc
-        instances = model.filter_query_by_customers_or_public(model.objects.filter(state=OWNED_OBJECT_STATE_LIVE), 
-            request.user.customer.get_visible_customers())
-        for relevant_change in relevant_changes:
-            if relevant_change.action == change_models.ACTION_CREATED:
-                instances.append(self.get_model().objects.get(pk=relevant_change.post.pk))
-            elif relevant_change.action == change_models.ACTION_MODIFIED:
-                instances = list(filter(lambda i: relevant_change.pre.uuid != i.uuid, instances))
-                instances.append(self.get_model().objects.get(pk=relevant_change.post.pk))
-            elif relevant_change.action == change_models.ACTION_DELETED:
-                instances = list(filter(lambda i: relevant_change.post.uuid != i.uuid, instances))
-            else:
-                raise ValueError('Action %s is not defined.' % relevant_change.action)
-        serialized_data = self.get_serializer()(instances, many=True).data
+                changeset = change_models.ChangeSet.objects.get(pk=UUID(self.request.GET['changeset']), owner__in=visible_customers)
+                return self.get_model().filter_by_changeset_and_visibility(query=self.get_model().objects.all(), changeset=changeset, visible_customers=visible_customers)
+            except ValueError as e:
+                raise e
+            except change_models.ChangeSet.DoesNotExist as e:
+                raise Http404 from e
+        else:
+            return self.get_model().filter_query_by_customers_or_public(self.get_model().objects.filter(state=OWNED_OBJECT_STATE_LIVE), visible_customers)
 
-        return Response(self.filter_attributes(serialized_data, request.user.customer))
-
-
-    def post(self, request, format=None):
-        serializer = self.get_serializer()(data=request.data)
-        changeset = change_models.ChangeSet(owner=request.user.customer, user=request.user, owner_name=request.user.customer.name, user_name=request.user.name)
-        if 'changeset' in request.GET:
-            changeset_id = UUID(request.GET['changeset'])
-            changeset = change_models.ChangeSet.objects.get(id=changeset_id)
-            if changeset.owner != request.user.customer:
-                return Response(data={'changeset':['access to this changeset is denied']}, status=status.HTTP_403_FORBIDDEN)
-            if changeset.applied is not None:
-                return Response({'changeset': CHANGESET_APPLIED_ERROR}, status=status.HTTP_400_BAD_REQUEST)
-        change = change_models.Change(entity=self.get_model().__name__, action=change_models.ACTION_CREATED)
-        
-        if serializer.is_valid():
-            if self.validate_owner():
-                visible_customers = request.user.customer.get_visible_customers()
-                if not serializer.validated_data['owner'] in visible_customers:
-                    return Response(data={'owner':['access to the owner is denied']}, status=status.HTTP_403_FORBIDDEN)
-            semantic_validation = self.post_validate(serializer.validated_data, request.user.customer, changeset)
-            if semantic_validation.is_ok():
-                changeset.save()
-                created_obj = serializer.save(state=OWNED_OBJECT_STATE_PREPARED)
-                change.changeset = changeset
-                change.post = created_obj
-                change.save()
-
-                serialized_object = self.get_serializer()(created_obj).data
-                serialized_object['changeset'] = str(changeset.id)
-                return Response(data=serialized_object, status=status.HTTP_201_CREATED)
-            else:
-                rtn_status = status.HTTP_400_BAD_REQUEST
-                if not semantic_validation.access_ok:
-                    rtn_status = status.HTTP_403_FORBIDDEN
-                return Response(data=semantic_validation.errors, status=rtn_status)
-        return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class GenericOwnedObjectDetail(RetrieveUpdateDestroyAPIView):
     permission_classes = [IsOwnerOfObjectOrPublicObject]
@@ -175,10 +130,6 @@ class GenericOwnedObjectDetail(RetrieveUpdateDestroyAPIView):
     @abstractmethod
     def get_model(self) -> Type[OwnedObject]:
         raise NotImplementedError('Model is not set.')
-
-    #@abstractmethod
-    #def get_serializer(self):
-    #    raise NotImplementedError('Serializer is not set.')
 
     @abstractmethod
     def filter_attributes(self, object: Any, customer: customer_models.Customer):
@@ -271,47 +222,6 @@ class GenericOwnedObjectDetail(RetrieveUpdateDestroyAPIView):
 
         return changeset
 
-    # def delete(self, request, uuid, format=None):
-    #     instance = None
-    #     changeset = None
-    #     change = None
-    #     if 'changeset' in request.GET:
-    #         try:
-    #             changeset = change_models.ChangeSet.objects.get(id=request.GET['changeset'])
-    #             if not changeset.owner in request.user.customer.get_visible_customers():
-    #                 return HttpResponseForbidden()
-    #             if changeset.applied is not None:
-    #                 return Response({'changeset': CHANGESET_APPLIED_ERROR}, status=status.HTTP_400_BAD_REQUEST)
-    #             thisname = self.get_model().__name__
-    #             for actual_change in changeset.changes.all():
-    #                 if actual_change.entity == thisname and actual_change.post.uuid == uuid:
-    #                     instance = self.get_model().objects.get(pk=actual_change.post.pk)
-    #                     change = actual_change
-    #                     break
-    #         except change_models.ChangeSet.DoesNotExist as dne_exc:
-    #             raise Http404() from dne_exc
-    #     if changeset is None:
-    #         changeset = change_models.ChangeSet(owner=request.user.customer, user=request.user, owner_name=request.user.customer.name, user_name=request.user.name)
-    #     if instance is None:
-    #         try:
-    #             pre_instance = self.get_model().objects.get(uuid=uuid, state=OWNED_OBJECT_STATE_LIVE)
-    #             instance = self.get_model().objects.get(pk=pre_instance.pk)
-    #             instance.id = None
-    #             instance.pk = None
-    #             instance._state.adding = True
-    #             change = change_models.Change(changeset=changeset, entity=self.get_model().__name__, pre=pre_instance, post=instance, action=change_models.ACTION_DELETED)
-    #         except self.get_model().DoesNotExist as dne_exc:
-    #             raise Http404() from dne_exc
-        
-    #     if not instance.owned_by(request.user.customer):
-    #         return Response(data={'uuid':['Access to object denied']}, status=status.HTTP_403_FORBIDDEN)
-        
-    #     changeset.save()
-    #     instance.state = OWNED_OBJECT_STATE_DELETED
-    #     instance.save()
-    #     change.save()
-        
-    #     return Response(data={'changeset':str(changeset.id)}, status=status.HTTP_200_OK)
 
 # def scan_for_owned_objects(module, _allowed_package: Optional[List[str]] = None, _accumulator: List[ModuleType] = []):
 #     rtn = {}

--- a/views/firewall_views.py
+++ b/views/firewall_views.py
@@ -122,7 +122,7 @@ class RuleSetList(GenericOwnedObjectList):
     def get_model(self):
         return models.RuleSet
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.RuleSetSerializer
 
     def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):

--- a/views/firewall_views.py
+++ b/views/firewall_views.py
@@ -13,14 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with VyCinity. If not, see <https://www.gnu.org/licenses/>.
 
-import copy
-from django.http import Http404
-from vycinity.models import AbstractOwnedObject, OwnedObject, customer_models, firewall_models, network_models, change_models, OWNED_OBJECT_STATE_LIVE, OWNED_OBJECT_STATE_PREPARED
 from vycinity.models import firewall_models as models
 from vycinity.serializers import firewall_serializers as serializers
-from vycinity.meta.change_management import ChangedObjectCollection
-from vycinity.views import GenericOwnedObjectList, GenericOwnedObjectDetail, VALIDATION_OK, ValidationResult, GenericOwnedObjectSchema
-from typing import Any, List
+from vycinity.views import GenericOwnedObjectList, GenericOwnedObjectDetail, GenericOwnedObjectSchema
 
 REFERENCED_OBJECT_NOT_FOUND = 'Referenced object not found'
 REFERENCED_OBJECT_ACCESS_DENIED = 'Access to referenced object is denied'
@@ -42,33 +37,8 @@ class FirewallList(GenericOwnedObjectList):
     def get_model(self):
         return models.Firewall
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.FirewallSerializer
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        rtn = []
-        for firewall_raw in object_list:
-            if not 'network' in firewall_raw or firewall_raw['network'] is None:
-                rtn.append(copy.deepcopy(firewall_raw))
-            else:
-                firewall_raw_mod = copy.deepcopy(firewall_raw)
-                network = network_models.Network.objects.get(uuid=firewall_raw['network'])
-                if not (network.public or network.owned_by(customer)):
-                    del firewall_raw_mod['network']
-                rtn.append(firewall_raw_mod)
-        return rtn
-
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return FirewallList.set_validate(object, customer, changeset)
-
-    @staticmethod
-    def set_validate(object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        if 'network' in object:
-            if not (object['network'].state == OWNED_OBJECT_STATE_LIVE or (object['network'].state == OWNED_OBJECT_STATE_PREPARED and object['network'].change.changeset == changeset)):
-                return ValidationResult(True, {'network': REFERENCED_OBJECT_INVALID_STATE})
-            if not object['network'].owned_by(customer):
-                return ValidationResult(False, {'network': REFERENCED_OBJECT_ACCESS_DENIED})
-        return VALIDATION_OK
 
 
 class FirewallDetailView(GenericOwnedObjectDetail):
@@ -93,18 +63,6 @@ class FirewallDetailView(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.FirewallSerializer
 
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        if not 'network' in object or object['network'] is None:
-            return copy.deepcopy(object)
-        else:
-            firewall_raw_mod = copy.deepcopy(object)
-            network = network_models.Network.objects.get(id=object['network'])
-            if not (network.public or network.owned_by(customer)):
-                del firewall_raw_mod['network']
-            return firewall_raw_mod
-
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet):
-        return FirewallList.set_validate(object, customer, changeset)
 
 class RuleSetList(GenericOwnedObjectList):
     '''
@@ -125,43 +83,6 @@ class RuleSetList(GenericOwnedObjectList):
     def get_serializer_class(self):
         return serializers.RuleSetSerializer
 
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        rtn = []
-        for object in object_list:
-            mod_object = copy.deepcopy(object)
-            mod_object['firewalls'] = []
-            for firewall_uuid in object['firewalls']:
-                firewall = models.Firewall.objects.get(uuid=firewall_uuid)
-                if firewall.public or firewall.owned_by(customer):
-                    mod_object['firewalls'].append(firewall_uuid)
-            rtn.append(mod_object)
-        return rtn
-
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return RuleSetList.set_allowed(object, customer, changeset)
-
-    @staticmethod
-    def set_allowed(object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        rtn = ValidationResult()
-        if object['owner'] not in customer.get_visible_customers():
-            rtn.errors = {'owner': [REFERENCED_OBJECT_ACCESS_DENIED]}
-            rtn.access_ok = False
-        if ('firewalls' in object and isinstance(object['firewalls'], list)):
-            target_visible_customers = object['owner'].get_visible_customers()
-            for firewall in object['firewalls']:
-                if firewall is None:
-                    rtn.errors = {'firewall': [REFERENCED_OBJECT_NOT_FOUND]}
-                    rtn.access_ok = True
-                    break
-                if not (firewall.public or firewall.owner in target_visible_customers):
-                    rtn.errors = {'firewall': [REFERENCED_OBJECT_ACCESS_DENIED]}
-                    rtn.access_ok = False
-                    break
-                elif not (firewall.state == OWNED_OBJECT_STATE_LIVE or (firewall.state == OWNED_OBJECT_STATE_PREPARED and firewall.change.changeset == changeset)):
-                    rtn.errors = {'firewall': [REFERENCED_OBJECT_INVALID_STATE]}
-                    rtn.access_ok = True
-                    break
-        return rtn
 
 class RuleSetDetailView(GenericOwnedObjectDetail):
     '''
@@ -184,26 +105,6 @@ class RuleSetDetailView(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.RuleSetSerializer
 
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        filtered_firewalls = []
-        for firewall_uuid in object['firewalls']:
-            firewall = models.Firewall.objects.get(uuid=firewall_uuid)
-            if firewall.public or firewall.owned_by(customer):
-                filtered_firewalls.append(firewall_uuid)
-        rtn = copy.deepcopy(object)
-        rtn['firewalls'] = filtered_firewalls
-        return rtn
-
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return RuleSetList.set_allowed(object, customer, changeset)
-
-def set_allowed_by_ruleset(object: dict, customer: customer_models.Customer) -> bool:
-    '''
-    Prüfe Schreib-Recht für angehängte RuleSets in basis-validierten dicts.
-    '''
-    if not object['related_ruleset'].owned_by(customer):
-        return False
-    return True
 
 class BasicRuleList(GenericOwnedObjectList):
     '''
@@ -222,38 +123,8 @@ class BasicRuleList(GenericOwnedObjectList):
     def get_model(self):
         return models.BasicRule
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.BasicRuleSerializer
-
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return BasicRuleList.set_allowed(object, customer, changeset)
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
-
-    def validate_owner(self):
-        return False
-
-    @staticmethod
-    def set_allowed(object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        rtn = ValidationResult()
-        if not set_allowed_by_ruleset(object, customer):
-            rtn.access_ok = False
-            rtn.errors = {'ruleset':[REFERENCED_OBJECT_ACCESS_DENIED]}
-            return rtn
-        rtn.access_ok = True
-        rtn.errors = {}
-        for attr in ['source_address', 'destination_address', 'destination_service']:
-            if attr in object and not object[attr] is None:
-                if not (object[attr].public or object[attr].owned_by(customer)):
-                    rtn.access_ok = False
-                    rtn.errors[attr] = [REFERENCED_OBJECT_ACCESS_DENIED]
-                    continue
-                if not (object[attr].state == OWNED_OBJECT_STATE_LIVE or (object[attr].state == OWNED_OBJECT_STATE_PREPARED and object[attr].change.changeset == changeset)):
-                    if attr not in rtn.errors:
-                        rtn.errors[attr] = []
-                    rtn.errors[attr].append(REFERENCED_OBJECT_INVALID_STATE)
-        return rtn
 
 
 class BasicRuleDetail(GenericOwnedObjectDetail):
@@ -278,14 +149,6 @@ class BasicRuleDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.BasicRuleSerializer
 
-    def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return BasicRuleList.set_allowed(object, customer, changeset)
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
-
-    def validate_owner(self):
-        return False
 
 class CustomRuleList(GenericOwnedObjectList):
     '''
@@ -305,17 +168,6 @@ class CustomRuleList(GenericOwnedObjectList):
     def get_serializer_class(self):
         return serializers.CustomRuleSerializer
 
-    def post_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> bool:
-        if set_allowed_by_ruleset(object, customer):
-            return VALIDATION_OK
-        else:
-            return ValidationResult(access_ok=False, errors={'ruleset':[REFERENCED_OBJECT_ACCESS_DENIED]})
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
-
-    def validate_owner(self):
-        return False
 
 class CustomRuleDetail(GenericOwnedObjectDetail):
     '''
@@ -339,17 +191,6 @@ class CustomRuleDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.CustomRuleSerializer
 
-    def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
-        if set_allowed_by_ruleset(object, customer):
-            return VALIDATION_OK
-        else:
-            return ValidationResult(access_ok=False, errors={'ruleset':[REFERENCED_OBJECT_ACCESS_DENIED]})
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
-    
-    def validate_owner(self):
-        return False
 
 class NetworkAddressObjectList(GenericOwnedObjectList):
     '''
@@ -366,22 +207,8 @@ class NetworkAddressObjectList(GenericOwnedObjectList):
     def get_model(self):
         return models.NetworkAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.NetworkAddressObjectSerializer
-
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return NetworkAddressObjectList.set_allowed_by_network(object, customer, changeset)
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
-
-    @staticmethod
-    def set_allowed_by_network(object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        if not object['network'].owned_by(customer):
-            return ValidationResult(access_ok=False, errors={'network':[REFERENCED_OBJECT_ACCESS_DENIED]})
-        if not (object['network'].state == OWNED_OBJECT_STATE_LIVE or (object['network'].state == OWNED_OBJECT_STATE_PREPARED and object['network'].change.changeset == changeset)):
-            return ValidationResult(access_ok=False, errors={'network':[REFERENCED_OBJECT_INVALID_STATE]})
-        return VALIDATION_OK
 
 
 class NetworkAddressObjectDetail(GenericOwnedObjectDetail):
@@ -405,11 +232,6 @@ class NetworkAddressObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.NetworkAddressObjectSerializer
 
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return NetworkAddressObjectList.set_allowed_by_network(object, customer, changeset)
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
 
 class CIDRAddressObjectList(GenericOwnedObjectList):
     '''
@@ -426,14 +248,9 @@ class CIDRAddressObjectList(GenericOwnedObjectList):
     def get_model(self):
         return models.CIDRAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.CIDRAddressObjectSerializer
 
-    def post_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
-        return VALIDATION_OK
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
 
 class CIDRAddressObjectDetail(GenericOwnedObjectDetail):
     '''
@@ -456,12 +273,6 @@ class CIDRAddressObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.CIDRAddressObjectSerializer
 
-    def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
-        return VALIDATION_OK
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
-
 class HostAddressObjectList(GenericOwnedObjectList):
     '''
     get:
@@ -477,14 +288,9 @@ class HostAddressObjectList(GenericOwnedObjectList):
     def get_model(self):
         return models.HostAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.HostAddressObjectSerializer
 
-    def post_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
-        return VALIDATION_OK
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
 
 class HostAddressObjectDetail(GenericOwnedObjectDetail):
     '''
@@ -507,37 +313,6 @@ class HostAddressObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.HostAddressObjectSerializer
 
-    def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
-        return VALIDATION_OK
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
-
-def set_allowed_by_elements(object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-    '''
-    Prüft die Schreibberechtigung für ein Listen-Objekt, das in seinem 'elements'-Attribut auf ein
-    anderes Model verweist.
-    '''
-    for element in object['elements']:
-        if not element.owned_by(customer) or element.public:
-            return ValidationResult(access_ok=False, errors={'elements':[REFERENCED_OBJECT_ACCESS_DENIED]})
-        if not (element.state == OWNED_OBJECT_STATE_LIVE or (element.state == OWNED_OBJECT_STATE_PREPARED and element.change.changeset == changeset)):
-            return ValidationResult(access_ok=False, errors={'elements':[REFERENCED_OBJECT_INVALID_STATE]})
-    return VALIDATION_OK
-
-def filter_attributes_by_elements(object: Any, customer: customer_models.Customer, dest_model):
-    '''
-    Filtert Elemente aus dem 'elements'-Attribut heraus, die nicht vom Customer oder öffentlich
-    sind.
-    '''
-    cleaned_object = copy.deepcopy(object)
-    cleaned_object['elements'] = []
-    for element_id in object['elements']:
-        element_object = dest_model.objects.get(id = element_id)
-        if element_object.public or element_object.owned_by(customer):
-            cleaned_object['elements'].append(element_id)
-    return cleaned_object
-
 class ListAddressObjectList(GenericOwnedObjectList):
     '''
     get:
@@ -553,17 +328,9 @@ class ListAddressObjectList(GenericOwnedObjectList):
     def get_model(self):
         return models.ListAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.ListAddressObjectSerializer
 
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return set_allowed_by_elements(object, object['owner'], changeset)
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        rtn = []
-        for object in object_list:
-            rtn.append(filter_attributes_by_elements(object, customer, self.get_model()))
-        return rtn
 
 class ListAddressObjectDetail(GenericOwnedObjectDetail):
     '''
@@ -586,11 +353,6 @@ class ListAddressObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.ListAddressObjectSerializer
 
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return set_allowed_by_elements(object, object['owner'], changeset)
-
-    def filter_attributes(self, object: List[Any], customer: customer_models.Customer):
-        return filter_attributes_by_elements(object, customer, self.get_model())
 
 class SimpleServiceObjectList(GenericOwnedObjectList):
     '''
@@ -607,14 +369,9 @@ class SimpleServiceObjectList(GenericOwnedObjectList):
     def get_model(self):
         return models.SimpleServiceObject
     
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.SimpleServiceObjectSerializer
 
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return VALIDATION_OK
-
-    def filter_attributes(self, object_list: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
 
 class SimpleServiceObjectDetail(GenericOwnedObjectDetail):
     '''
@@ -637,11 +394,6 @@ class SimpleServiceObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.SimpleServiceObjectSerializer
 
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return VALIDATION_OK
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
 
 class RangeServiceObjectList(GenericOwnedObjectList):
     '''
@@ -658,14 +410,9 @@ class RangeServiceObjectList(GenericOwnedObjectList):
     def get_model(self):
         return models.RangeServiceObject
     
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.RangeServiceObjectSerializer
 
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return VALIDATION_OK
-
-    def filter_attributes(self, object_list: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object_list)
 
 class RangeServiceObjectDetail(GenericOwnedObjectDetail):
     '''
@@ -688,11 +435,6 @@ class RangeServiceObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.RangeServiceObjectSerializer
 
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return VALIDATION_OK
-
-    def filter_attributes(self, object: Any, customer: customer_models.Customer):
-        return copy.deepcopy(object)
 
 class ListServiceObjectList(GenericOwnedObjectList):
     '''
@@ -712,14 +454,6 @@ class ListServiceObjectList(GenericOwnedObjectList):
     def get_serializer(self):
         return serializers.ListServiceObjectSerializer
 
-    def post_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return set_allowed_by_elements(object, object['owner'], changeset)
-
-    def filter_attributes(self, object_list: List[Any], customer: customer_models.Customer):
-        rtn = []
-        for object in object_list:
-            rtn.append(filter_attributes_by_elements(object, customer, self.get_model()))
-        return rtn
 
 class ListServiceObjectDetail(GenericOwnedObjectDetail):
     '''
@@ -742,8 +476,3 @@ class ListServiceObjectDetail(GenericOwnedObjectDetail):
     def get_serializer_class(self):
         return serializers.ListServiceObjectSerializer
 
-    def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
-        return set_allowed_by_elements(object, object['owner'], changeset)
-
-    def filter_attributes(self, object: List[Any], customer: customer_models.Customer):
-        return filter_attributes_by_elements(object, customer, self.get_model())

--- a/views/firewall_views.py
+++ b/views/firewall_views.py
@@ -90,7 +90,7 @@ class FirewallDetailView(GenericOwnedObjectDetail):
     def get_model(self):
         return models.Firewall
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.FirewallSerializer
 
     def filter_attributes(self, object: Any, customer: customer_models.Customer):
@@ -181,7 +181,7 @@ class RuleSetDetailView(GenericOwnedObjectDetail):
     def get_model(self):
         return models.RuleSet
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.RuleSetSerializer
 
     def filter_attributes(self, object: Any, customer: customer_models.Customer):
@@ -275,7 +275,7 @@ class BasicRuleDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.BasicRule
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.BasicRuleSerializer
 
     def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
@@ -302,7 +302,7 @@ class CustomRuleList(GenericOwnedObjectList):
     def get_model(self):
         return models.CustomRule
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.CustomRuleSerializer
 
     def post_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> bool:
@@ -336,7 +336,7 @@ class CustomRuleDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.CustomRule
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.CustomRuleSerializer
 
     def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
@@ -402,7 +402,7 @@ class NetworkAddressObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.NetworkAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.NetworkAddressObjectSerializer
 
     def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
@@ -453,7 +453,7 @@ class CIDRAddressObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.CIDRAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.CIDRAddressObjectSerializer
 
     def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
@@ -504,7 +504,7 @@ class HostAddressObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.HostAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.HostAddressObjectSerializer
 
     def put_validate(self, object: Any, customer: customer_models.Customer, changeset: change_models.ChangeSet):
@@ -583,7 +583,7 @@ class ListAddressObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.ListAddressObject
 
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.ListAddressObjectSerializer
 
     def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
@@ -634,7 +634,7 @@ class SimpleServiceObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.SimpleServiceObject
     
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.SimpleServiceObjectSerializer
 
     def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
@@ -685,7 +685,7 @@ class RangeServiceObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.RangeServiceObject
     
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.RangeServiceObjectSerializer
 
     def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:
@@ -739,7 +739,7 @@ class ListServiceObjectDetail(GenericOwnedObjectDetail):
     def get_model(self):
         return models.ListServiceObject
     
-    def get_serializer(self):
+    def get_serializer_class(self):
         return serializers.ListServiceObjectSerializer
 
     def put_validate(self, object: dict, customer: customer_models.Customer, changeset: change_models.ChangeSet) -> ValidationResult:


### PR DESCRIPTION
The previously self written generic API was not able to paginate nor to filter. The generics of django-rest-framework are prepared for this and so it was more useful to use the existing pagination and filters instead of rewriting the logic for this project. Only maybe ugly thing: The logic of finding the visible customers or their object is now split up to multiple places.

Thanks to @wornet-aer for thinking.